### PR TITLE
allows a new slot to be called once using memoized arguments from the most recent dispatch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -136,9 +136,9 @@ export class Signal<T extends Function = (() => void)>
     }
 
     /**
-     * Binds a new handler function to this signal that may be called once using the memoized 
-     * value from the most recent dispatch, and will be called for each subsequent
-     * dispatches.
+     * Binds a new handler function to this signal that will be called once synchronously with 
+     * the add using the memoized value from the previous dispatch. The handler is called with
+     * each subsequent dispatch like a normal `add`.
      * 
      * @param fn The handler function to bind.
      * @param thisArg Optional `this` argument to use when calling this handler

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,9 +136,9 @@ export class Signal<T extends Function = (() => void)>
     }
 
     /**
-     * Binds a new handler function to this signal that will be called once synchronously with 
-     * the add using the memoized value from the previous dispatch. The handler is called with
-     * each subsequent dispatch like a normal `add`.
+     * Binds a new handler function to this signal that will be called once using the memoized value
+     * from the previous dispatch. The handler is called with each subsequent dispatch, the same as a 
+     * normal `add`.
      * 
      * @param fn The handler function to bind.
      * @param thisArg Optional `this` argument to use when calling this handler

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,8 @@ export class Signal<T extends Function = (() => void)>
     }
 
     /**
-     * Binds a new handler function to this signal that will may be called once using the 
-     * memoized value from the most recent dispatch, and will be called for each subsequent
+     * Binds a new handler function to this signal that may be called once using the memoized 
+     * value from the most recent dispatch, and will be called for each subsequent
      * dispatches.
      * 
      * @param fn The handler function to bind.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,13 +57,34 @@ describe('Signal', function ()
     describe('#memo', function () {
         it('calls the a signal added with the memoized value', function() 
         {
-            const sp = spy();
-            const s = new Signal<(a: number, b: number, c: string) => void>();
+            const sp0 = spy();
+            const s0 = new Signal<(a: number, b: number, c: string) => void>();
 
-            s.dispatch(1, 2, 'bar');
-            s.addMemo(sp);
+            s0.dispatch(1, 2, 'bar');
+            s0.addMemo(sp0);
 
-            expect(sp).to.be.calledOnceWithExactly(1, 2, 'bar');
+            expect(sp0).to.be.calledOnceWithExactly(1, 2, 'bar');
+
+            s0.dispatch(3, 4, 'foo');
+            expect(sp0).to.be.calledWith(3, 4, 'foo')
+
+            const sp1 = spy();
+            s0.addMemo(sp1)
+            expect(sp1).to.be.calledOnceWithExactly(3, 4, 'foo');
+        });
+        it('does not memoize values for regular adds', function() 
+        {
+            const sp0 = spy();
+            const s0 = new Signal<(a: number, b: number, c: string) => void>();
+
+            s0.dispatch(1, 2, 'bar');
+            s0.addMemo(sp0);
+
+            expect(sp0).to.be.calledOnceWithExactly(1, 2, 'bar');
+
+            const sp1 = spy();
+            s0.add(sp1)
+            expect(sp1).to.not.be.to.not.have.been.called;
         });
     });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -54,6 +54,19 @@ describe('Signal', function ()
         });
     });
 
+    describe('#memo', function () {
+        it('calls the a signal added with the memoized value', function() 
+        {
+            const sp = spy();
+            const s = new Signal<(a: number, b: number, c: string) => void>();
+
+            s.dispatch(1, 2, 'bar');
+            s.addMemo(sp);
+
+            expect(sp).to.be.calledOnceWithExactly(1, 2, 'bar');
+        });
+    });
+
     describe('#dispatch', function ()
     {
         it('calls each of the handlers', function ()


### PR DESCRIPTION
I find this pattern useful when some piece of UI needs the state from a signal on its first render, this allows this:
```
let state = getState();
updateUiWithState(state);
Signal.add((state) => {
  updateUiWithState(state);
}
```

to become this:
```
Signal.addMemo((state) => { 
  updateUiWithState(state);
}
```